### PR TITLE
62 dont log show right after a model was created

### DIFF
--- a/lib/loggable_activity/hooks.rb
+++ b/lib/loggable_activity/hooks.rb
@@ -104,13 +104,16 @@ module LoggableActivity
 
     def just_created?
       action = self.class.base_action + ".create"
-      return 
-      LoggableActivity::Activity.where(record: self, actor: @actor).last.action == action
+      activity = LoggableActivity::Activity.where(record: self, actor: @actor).last
+      return false unless activity && activity.action == action && activity.created_at > 5.seconds.ago
+      true
     end
 
     def just_updated?
       action = self.class.base_action + ".update"
-      LoggableActivity::Activity.where(record: self, actor: @actor).last.action == action
+      activity = LoggableActivity::Activity.where(record: self, actor: @actor).last
+      return false unless activity && activity.action == action && activity.created_at > 5.seconds.ago
+      true
     end
 
     # Creates an activity with the specified payloads.

--- a/lib/loggable_activity/hooks.rb
+++ b/lib/loggable_activity/hooks.rb
@@ -50,8 +50,10 @@ module LoggableActivity
       @payloads = []
 
       case action
-      when :create, :show
-        log_activity
+      when :create
+        log_create
+      when  :show
+        log_show
       when :destroy
         log_destroy
       when :update
@@ -73,9 +75,16 @@ module LoggableActivity
 
     private
 
-    # Logs an activity for the current action.
-    def log_activity
-      create_activity(build_payloads)
+    # Logs an activity for the show action.
+    def log_show
+      return nil if just_created?
+      return nil if just_updated?
+      log_activity 
+    end
+
+    # Logs an activity for the create action.
+    def log_create
+      log_activity
     end
 
     # Logs an activity for the update action.
@@ -86,6 +95,22 @@ module LoggableActivity
     # Logs an activity for the destroy action.
     def log_destroy
       create_activity(build_destroy_payload)
+    end
+
+    # Logs an activity for the current action.
+    def log_activity
+      create_activity(build_payloads)
+    end
+
+    def just_created?
+      action = self.class.base_action + ".create"
+      return 
+      LoggableActivity::Activity.where(record: self, actor: @actor).last.action == action
+    end
+
+    def just_updated?
+      action = self.class.base_action + ".update"
+      LoggableActivity::Activity.where(record: self, actor: @actor).last.action == action
     end
 
     # Creates an activity with the specified payloads.

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -153,4 +153,14 @@ class HooksTest < ActiveSupport::TestCase
       assert_equal @params.dig(:order, :items).length, payload_attrs[:attrs][:order][:items].length
     end
   end
+
+  class DontLogAfterCreate < HooksTest
+    test 'it does not log after create' do
+      user = create(:user)
+      activity = LoggableActivity::Activity.last
+      user.log(:show, actor: @current_user)
+      assert_equal activity, LoggableActivity::Activity.last
+      # assert_nil LoggableActivity::Activity.last
+    end
+  end
 end

--- a/test/hooks_test.rb
+++ b/test/hooks_test.rb
@@ -45,6 +45,8 @@ class HooksTest < ActiveSupport::TestCase
 
     test 'it logs show' do
       user = create(:user)
+      activity = LoggableActivity::Activity.last
+      activity.update(created_at: 6.seconds.ago)
       user.log(:show, actor: @current_user)
       activity = LoggableActivity::Activity.last
 
@@ -110,6 +112,8 @@ class HooksTest < ActiveSupport::TestCase
 
     test 'it logs show, with belongs_to relation' do
       user = create(:user)
+      activity = LoggableActivity::Activity.last
+      activity.update(created_at: 6.seconds.ago)
       user.log(:show, actor: @current_user)
 
       activity = LoggableActivity::Activity.last
@@ -155,12 +159,38 @@ class HooksTest < ActiveSupport::TestCase
   end
 
   class DontLogAfterCreate < HooksTest
-    test 'it does not log after create' do
+    test 'it does not log show after create' do
       user = create(:user)
       activity = LoggableActivity::Activity.last
       user.log(:show, actor: @current_user)
       assert_equal activity, LoggableActivity::Activity.last
-      # assert_nil LoggableActivity::Activity.last
+    end
+    
+    test 'it does log show after create if it was created more than 5 sec ago' do
+      user = create(:user)
+      activity = LoggableActivity::Activity.last
+      activity.update(created_at: 6.seconds.ago)
+      user.log(:show, actor: @current_user)
+      refute_equal activity, LoggableActivity::Activity.last
+    end
+  end
+
+  class DontLogAfterUpdate < HooksTest
+    test 'it does not log show after update' do
+      user = create(:user)
+      user.update(first_name: "#{user.first_name}_Updated")
+      activity = LoggableActivity::Activity.last
+      user.log(:show, actor: @current_user)
+      assert_equal activity, LoggableActivity::Activity.last
+    end
+    
+    test 'it does log show after update if it was updated more than 5 sec ago' do
+      user = create(:user)
+      user.update(first_name: "#{user.first_name}_Updated")
+      activity = LoggableActivity::Activity.last
+      activity.update(created_at: 6.seconds.ago)
+      user.log(:show, actor: @current_user)
+      refute_equal activity, LoggableActivity::Activity.last
     end
   end
 end


### PR DESCRIPTION
## When a model is created or updatet, sometime the controler redirect to show, in that case it should not log the show action



## Checklist

- [x] I have tested these changes locally
- [x] I have executed 'rubocop' locally
- [] I have executed 'brakeman' locally
- [] I have reviewed the code and provided feedback if needed
- [] I have updated the documentation if necessary
- [] I have updated the the version number in README.md



