### PR TITLE
#87 Remove redundant public attributes

### DIFF
--- a/lib/loggable_activity/activity.rb
+++ b/lib/loggable_activity/activity.rb
@@ -80,8 +80,7 @@ module LoggableActivity
           route: payload.payload_route,
           record_display_name: payload.fetch_record_display_name,
           current_payload: payload.current_payload,
-          data_owner: payload.data_owner,
-          public_attrs: payload.public_attrs
+          data_owner: payload.data_owner
         }
       end
     end


### PR DESCRIPTION
## Description 
The activity shows public attributes twice.

## Related Issues
https://github.com/LoggableActivity/LoggableActivity/issues/87

## Checklist

- [x] I have tested these changes locally
- [x] I have executed 'rubocop' locally
- [x] I have executed 'brakeman' locally
- [x] I have reviewed the code and provided feedback if needed
- [] I have updated the documentation if necessary
- [] I have updated the the version number in README.md



